### PR TITLE
Fix dpi problem

### DIFF
--- a/Example3_EvolveAPainting.py
+++ b/Example3_EvolveAPainting.py
@@ -136,7 +136,7 @@ def create_image(vector):
         colors.append([color[i] for i in range(3)])
 
     # creates a figure of the same dimension as source image
-    fig, ax = plt.subplots(figsize=(xsize/dpi, ysize/dpi))
+    fig, ax = plt.subplots(figsize=(xsize/dpi, ysize/dpi), dpi=dpi)
     ax.set_rasterization_zorder(1)
 
     # creates a collection of polygonal shapes


### PR DESCRIPTION
The dimensions of `compute_images_mse` function's parameters `source_image` and `new_image` were different on my machine. 

After some inspection, I found the problem was with `dpi`. [The default dpi in matplotlib is `100`.](https://matplotlib.org/3.2.1/api/_as_gen/matplotlib.pyplot.figure.html#matplotlib-pyplot-figure) However in the code, the `dpi` is declared as `80` on `line 91`.

 Explicitly writing the dpi on the subplot on `line 139` fixes this problem.